### PR TITLE
Fix/shebang

### DIFF
--- a/.changeset/friendly-adults-travel.md
+++ b/.changeset/friendly-adults-travel.md
@@ -1,0 +1,7 @@
+---
+"css-find-vars": patch
+---
+
+fix(build): add shebang string
+
+- Add build.cli.js script to insert shebang (#!/usr/bin/env node) to the compiled CLI executable.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node scripts/build.cli.js",
     "start": "node dist/index.js",
     "lint": "eslint . --ext .ts && tsc --noEmit",
     "release": "npm run build && npx changeset publish"

--- a/scripts/build.cli.js
+++ b/scripts/build.cli.js
@@ -1,0 +1,10 @@
+const fs = require("fs");
+const path = require("path");
+
+const filePath = path.resolve(__dirname, "../dist/index.js");
+const data = fs.readFileSync(filePath, "utf8");
+
+if (!data.startsWith("#!/usr/bin/env node")) {
+  const shebang = "#!/usr/bin/env node\n";
+  fs.writeFileSync(filePath, shebang + data);
+}


### PR DESCRIPTION
Add `build.cli.js` script to insert shebang (`#!/usr/bin/env node`) to the compiled CLI executable.

Resolves #12 